### PR TITLE
Remove propshaft, update README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 8.1.2"
 
 # Assets & front end
-gem "propshaft"
 gem "vite_rails", "~> 3.0"
 
 # Deployment and drivers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,10 +217,6 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    propshaft (1.3.1)
-      actionpack (>= 7.0.0)
-      activesupport (>= 7.0.0)
-      rack
     psych (5.3.1)
       date
       stringio
@@ -411,7 +407,6 @@ DEPENDENCIES
   inertia_rails
   kamal
   pg (~> 1.1)
-  propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
   selenium-webdriver
@@ -516,7 +511,6 @@ CHECKSUMS
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
   puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Shore is a Ruby on Rails template with a modern stack to start your next project
 - **PostgreSQL** — [PostgreSQL 18](https://www.postgresql.org)
 - **React + Inertia.js** — [Inertia Rails](https://inertia-rails.dev)
 - **Tailwind CSS** — [Tailwind CSS v4](https://tailwindcss.com)
-- **Bun** — [Bun](https://bun.sh) for js package management and asset bundling
+- **Vite** — [Vite](https://vite.dev) for asset bundling via [vite_rails](https://vite-ruby.netlify.app)
+- **Bun** — [Bun](https://bun.sh) for JavaScript package management
 - **Solid Queue** — [Solid Queue](https://github.com/rails/solid_queue) for background jobs
 - **Solid Cache** — [Solid Cache](https://github.com/rails/solid_cache) for caching
 - **Solid Cable** — [Solid Cable](https://github.com/rails/solid_cable) for WebSockets

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,9 +62,6 @@ Rails.application.configure do
   # Highlight code that triggered redirect in logs.
   config.action_dispatch.verbose_redirect_logs = true
 
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = "1.0"


### PR DESCRIPTION
## Summary
- Remove `propshaft` gem — Vite now handles all asset bundling, so the separate asset pipeline is unnecessary
- Delete `config/initializers/assets.rb` and remove `config.assets.quiet` from development.rb (both depended on propshaft)
- Update README to list Vite and Bun as separate features

## Test plan
- [x] `bun run check` — TypeScript passes
- [x] `bin/rails test` — 4 runs, 15 assertions, 0 failures
- [x] Production asset precompile works
- [ ] CI passes